### PR TITLE
Use case 8

### DIFF
--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -23,6 +23,8 @@ namespace Grocery.App.ViewModels
         GroceryList groceryList = new(0, "None", DateOnly.MinValue, "", 0);
         [ObservableProperty]
         string myMessage;
+        [ObservableProperty]
+        public string searchTerm;
 
         public GroceryListItemsViewModel(IGroceryListItemsService groceryListItemsService, IProductService productService, IFileSaverService fileSaverService)
         {
@@ -83,6 +85,28 @@ namespace Grocery.App.ViewModels
             catch (Exception ex)
             {
                 await Toast.Make($"Opslaan mislukt: {ex.Message}").Show(cancellationToken);
+            }
+        }
+
+        [RelayCommand]
+        private void SearchProducts()
+        {
+            if (string.IsNullOrWhiteSpace(searchTerm))
+            {
+                GetAvailableProducts();
+                return;
+            }
+
+            var filtered = _productService.GetAll()
+                .Where(p => p.Stock > 0 &&
+                            MyGroceryListItems.All(g => g.ProductId != p.Id) &&
+                            p.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            AvailableProducts.Clear();
+            foreach (var p in filtered)
+            {
+                AvailableProducts.Add(p);
             }
         }
 

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -54,6 +54,14 @@
 
         <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <StackLayout>
+
+                <SearchBar x:Name="ProductSearchBar"
+                           Placeholder="Zoek producten..."
+                           Text="{Binding SearchTerm, Mode=TwoWay}"
+                           SearchCommand="{Binding SearchProductsCommand}"
+                           Margin="5"/>
+
+
                 <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
                     SelectionMode="Single"
                     SelectionChangedCommand="{Binding AddProductCommand}"

--- a/Grocery.Core.Data/Repositories/usecase8testbranch.cs
+++ b/Grocery.Core.Data/Repositories/usecase8testbranch.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grocery.Core.Data.Repositories
+{
+    internal class usecase8testbranch
+    {
+        //dit is commentaar of te zien of de use case 8 branch werkt//
+    }
+}


### PR DESCRIPTION
use case 8 pull request dit is wat in de use case 8 gebeurt moest worden

UC08 Zoeken producten

Aanvullen:

    In de GroceryListItemsView zitten twee Collection Views, namelijk één voor de inhoud van de boodschappenlijst en één voor producten die je toe kunt voegen aan de boodschappenlijst
    Voeg boven de tweede CollectionView een zoekveld (SearchBar) in om op producten te kunnen zoeken.
    Zorg dat de SearchCommand wordt gebonden aan een functie in het onderliggende ViewModel (GroceryListItemsViewModel) en dat de zoekterm die in het zoekveld is ingetypt gebruikt wordt als parameter (SearchCommandParameter).
    Werk in het viewModel (GroceryListItemsViewModel) de zoekfunctie uit en zorg dat de beschikbare producten worden gefilterd op de zoekterm!
